### PR TITLE
Feat/node drag pinning

### DIFF
--- a/lineage_dash_app_full_export.py
+++ b/lineage_dash_app_full_export.py
@@ -1,4 +1,4 @@
-import json
+import json 
 import base64
 import io
 import dash

--- a/lineage_dash_app_full_export.py
+++ b/lineage_dash_app_full_export.py
@@ -84,6 +84,18 @@ app.layout = html.Div([
             placeholder="Select a gene to color nodes",
             style={"width": "300px"}
         ),
+        html.Label("Layout:"),
+dcc.Dropdown(
+    id="layout-selector",
+    options=[
+        {"label": "Tree (Breadthfirst)", "value": "breadthfirst"},
+        {"label": "Radial (Circle)", "value": "circle"}
+    ],
+    value="breadthfirst",
+    style={"width": "300px"}
+),
+html.Br(),
+
         html.Br(),
         html.Label("Search Cell by Name:"),
         dcc.Input(id="cell-search", type="text", placeholder="e.g., EMS", debounce=True),
@@ -147,6 +159,14 @@ def center_on_node(cell_name, elements):
     Input("btn-download-json", "n_clicks"),
     prevent_initial_call=True
 )
+
+@app.callback(
+    Output("cytoscape-lineage", "layout"),
+    Input("layout-selector", "value")
+)
+def update_layout(layout_name):
+    return {"name": layout_name}
+
 def download_json(n):
     lineage_json = nx.node_link_data(G)
     return send_string(json.dumps(lineage_json, indent=2), "lineage.json")

--- a/lineage_dash_app_full_export.py
+++ b/lineage_dash_app_full_export.py
@@ -120,6 +120,18 @@ app.layout = html.Div([
         layout={"name": "breadthfirst"},
         style={"width": "100%", "height": "600px"},
     ),
+    cyto.Cytoscape(
+    id="cytoscape-lineage",
+    elements=nx_to_cytoscape(G),
+    layout={"name": "breadthfirst"},
+    style={"width": "100%", "height": "600px"},
+    userZoomingEnabled=True,
+    userPanningEnabled=True,
+    boxSelectionEnabled=True,
+    autoungrabify=False,  # allow user to grab/move nodes
+    autolock=False        # nodes are not locked by default
+),
+
     html.Div([
         html.Button("⬇️ Download JSON", id="btn-download-json"),
         Download(id="download-json"),


### PR DESCRIPTION
This PR enables users to freely drag nodes to new positions in the lineage graph. Nodes are movable by default and persist visually throughout the session. This is useful for rearranging crowded graphs or highlighting custom regions during exploration.
